### PR TITLE
Don't include debug info by default (and version updates)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 var ejs = require('ejs')
   , through = require('through')
 
-module.exports = function(file) {
+module.exports = function(file, options) {
   if (!/\.ejs$/.test(file)) return through()
+
+  options = options || {};
 
   var buffer = ""
 
@@ -11,6 +13,8 @@ module.exports = function(file) {
   }, function end() {
     var template = ejs.compile(buffer, {
         client: true
+      , debug: options.debug || false
+      , compileDebug: options.compileDebug || false
       , filename: file
     })
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "main": "index.js",
   "dependencies": {
     "ejs": "~0.8.3",
-    "through": "~2.2.7"
+    "through": "~2.3.4"
   },
   "devDependencies": {
-    "browserify": "~2.11.0"
+    "browserify": "~3.32.1"
   },
   "description": "EJS precompiler for browserify",
   "keywords": [


### PR DESCRIPTION
To include debug info: `browserify -t [ejsify --debug --compileDebug]`
