### PR TITLE
prevent "double" transforms (caused by watchify)

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,13 +11,18 @@ module.exports = function(file, options) {
   return through(function write(chunk) {
     buffer += chunk
   }, function end() {
-    var template = ejs.compile(buffer, {
-        client: true
-      , compileDebug: options.debug || false
-      , filename: file
-    })
-
-    this.queue('module.exports = (' + template + ')')
+    if (buffer.indexOf('module.exports') === 0) {
+      this.queue(buffer); // prevent "double" transforms 
+    } else {
+      
+      var template = ejs.compile(buffer, {
+          client: true
+        , compileDebug: options.debug || false
+        , filename: file
+      })
+  
+      this.queue('module.exports = (' + template + ')')
+    }
     this.queue(null)
   })
 }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,14 @@
 var ejs = require('ejs')
   , through = require('through')
 
+
+var extensions = {
+  ejs: 1,
+  html: 1
+};
+
 module.exports = function(file, options) {
-  if (!/\.ejs$/.test(file)) return through()
+  if (!extensions[file.split(".").pop()]) return through();
 
   options = options || {}
 


### PR DESCRIPTION
when using watchify, required templates get compiled as needed up the require stream. 

in the wild: 

```
// file: app.js
module.exports = function({
  require('template.ejs)
})
```

using watchify, a change to `template.ejs` would trigger a transform of `template.ejs`, and then of `app.js`. at that point everything gets messed up.
